### PR TITLE
Add Homebrew tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ A CLI tool to calculate Capital Gains Tax for UK assets using the "Same Day", "B
 
 ## Installation
 
+### Homebrew (macOS & Linux)
+
+```bash
+brew tap velikodniy/tap
+brew install cgt-tool
+cgt-tool --version
+```
+
 ### Pre-built Binaries (Recommended)
 
 Download the latest release for your platform from [GitHub Releases](https://github.com/vadim-projects/cgt-tool/releases):

--- a/openspec/changes/publish-homebrew-formula/design.md
+++ b/openspec/changes/publish-homebrew-formula/design.md
@@ -1,0 +1,37 @@
+# Design
+
+## Scope
+
+Publish `cgt-tool` through the existing `velikodniy/homebrew-tap`, using prebuilt GitHub release binaries and keeping the formula current via automation. No changes to the Rust workspace are required; work is split between the tap (formula + workflow) and the main repo (docs).
+
+## Formula layout
+
+- Use upstream release assets directly to avoid slow source builds: `cgt-tool-macos-aarch64`, `cgt-tool-macos-x86_64`, `cgt-tool-linux-aarch64`, `cgt-tool-linux-x86_64` from tag `vX.Y.Z`.
+- Structure with `on_macos` and `on_linux` blocks, each specifying `url`, `sha256`, and `on_intel`/`on_arm` to map to the correct binary.
+- Install by renaming the downloaded asset to `cgt-tool` (dropping extension) via `bin.install`.
+- `test do` runs `cgt-tool --version` to confirm the binary links on the host.
+
+## Checksum source
+
+- Prefer the published `checksums.txt` asset for versioned SHA256 values; fall back to computing checksums after downloading each asset if needed.
+- Keep SHA updates deterministic so automation can rewrite the formula without manual edits.
+
+## Automation approach
+
+- Add a workflow in the tap repo (no OpenSpec tooling there) that:
+  - Triggers on a schedule and `workflow_dispatch`; optionally accept a target tag input.
+  - Fetches the latest `velikodniy/cgt-tool` release via GitHub API.
+  - Compares the tag to the current `VERSION` in `Formula/cgt-tool.rb` to decide whether to update.
+  - Downloads `checksums.txt` (or assets) to populate per-arch SHA256s and rewrites the formula URLs/version/sha fields.
+  - Runs a smoke install (`brew install velikodniy/tap/cgt-tool && cgt-tool --version`) on macOS; Linux run is optional but planned when runners are available.
+  - Commits and pushes the formula change (or opens a PR) with the updated version.
+
+## Documentation updates
+
+- cgt-tool README gains a Homebrew installation section showing `brew tap velikodniy/tap` and `brew install cgt-tool`.
+- Tap README lists `cgt-tool` alongside existing formulas.
+
+## Open questions
+
+- Whether to keep Linux binaries in the formula initially; scope assumes yes since release assets exist, but this can be limited to macOS if audit tooling requires it.
+- Whether automation should open PRs vs direct pushes; default to direct push (matching `update-openspec`) unless reviewer sign-off is required.

--- a/openspec/changes/publish-homebrew-formula/proposal.md
+++ b/openspec/changes/publish-homebrew-formula/proposal.md
@@ -1,0 +1,29 @@
+# Change: Publish cgt-tool via Homebrew Tap
+
+## Why
+
+- Issue #5 requests easy installation through the existing `velikodniy/homebrew-tap` instead of manual binary downloads.
+- Homebrew formulae need explicit checksums per platform; keeping them in a tap improves discoverability and updates.
+- Automating formula refreshes prevents stale versions and reduces manual checksum maintenance.
+
+## What Changes
+
+- Add a `Formula/cgt-tool.rb` in `velikodniy/homebrew-tap` that downloads release binaries for macOS (arm64/x86_64) and Linux (arm64/x86_64), with matching SHA256 per asset and a `--version` smoke test.
+- Document Homebrew installation in the cgt-tool README (and list it in the tap README) using `brew tap velikodniy/tap` and `brew install cgt-tool`.
+- Add GitHub Actions automation to update the tap formula when new cgt-tool releases publish, reusing release checksums and committing the version bump, plus an on-demand trigger.
+- Validate installation on macOS runners (and Linux where applicable) as part of the automation to ensure the binary runs after formula updates.
+
+## Impact
+
+- Affected specs: updates under `ci` for tap distribution and automation.
+- Affected files/repos:
+  - `velikodniy/homebrew-tap`: `Formula/cgt-tool.rb` (new), README entry, workflow for formula updates/tests.
+  - `velikodniy/cgt-tool`: README installation section for Homebrew.
+- No changes to the Rust codebase or release artifacts are expected.
+
+## Design Considerations
+
+- Use release asset names (`cgt-tool-macos-aarch64`, `cgt-tool-macos-x86_64`, `cgt-tool-linux-aarch64`, `cgt-tool-linux-x86_64`) with explicit URLs and checksums rather than building from source inside the formula to keep install fast.
+- Prefer `brew test` to call `cgt-tool --version` for a quick sanity check without needing sample data.
+- Formula update workflow should avoid duplicating OpenSpec tooling and run entirely within the tap repo, triggered by cgt-tool releases or manual dispatch.
+- If future releases add bottles or universal binaries, keep the formula structure segmented (`on_macos` / `on_linux`) to swap sources without changing consumers.

--- a/openspec/changes/publish-homebrew-formula/specs/ci/spec.md
+++ b/openspec/changes/publish-homebrew-formula/specs/ci/spec.md
@@ -1,0 +1,52 @@
+# CI
+
+## ADDED Requirements
+
+### Requirement: Homebrew Tap Distribution
+
+The system SHALL provide a Homebrew tap formula to install `cgt-tool` from `velikodniy/tap`.
+
+#### Scenario: Install via tap
+
+- **WHEN** a user runs `brew tap velikodniy/tap` followed by `brew install cgt-tool`
+- **THEN** installation succeeds on supported macOS architectures (Intel and Apple Silicon) and Linux
+- **AND** running `cgt-tool --version` returns the tagged release version.
+
+#### Scenario: Release-sourced binaries
+
+- **WHEN** installing via the tap formula on macOS or Linux
+- **THEN** the URL for each architecture matches the corresponding GitHub release asset
+- **AND** the formula SHA256 matches the published checksum for that asset.
+
+#### Scenario: Documented install path
+
+- **WHEN** users view installation docs
+- **THEN** the cgt-tool README shows `brew tap velikodniy/tap` and `brew install cgt-tool`
+- **AND** the tap README lists `cgt-tool` with a tap-install snippet.
+
+### Requirement: Homebrew Formula Automation
+
+The system SHALL keep the tap formula updated automatically when new `cgt-tool` releases are published.
+
+#### Scenario: Release-triggered update
+
+- **WHEN** a newer `velikodniy/cgt-tool` release tag exists than the version in `Formula/cgt-tool.rb`
+- **THEN** the workflow updates the formula version, URLs, and SHA256 values to that release
+- **AND** commits or opens a pull request in `velikodniy/homebrew-tap` to apply the change.
+
+#### Scenario: Manual rerun
+
+- **WHEN** a maintainer triggers the workflow manually with a target tag
+- **THEN** the workflow reuses the same update logic to rewrite the formula for the requested release.
+
+#### Scenario: Checksum integrity
+
+- **WHEN** the workflow prepares a formula update
+- **THEN** it sources checksums from the release artifacts (e.g., `checksums.txt` or downloaded assets) for macOS and Linux architectures
+- **AND** the run fails if any expected checksum is missing or mismatched.
+
+#### Scenario: Automated smoke install
+
+- **WHEN** the workflow finishes rewriting the formula
+- **THEN** it installs `velikodniy/tap/cgt-tool` on macOS
+- **AND** `cgt-tool --version` returns the updated release tag before changes are pushed.

--- a/openspec/changes/publish-homebrew-formula/tasks.md
+++ b/openspec/changes/publish-homebrew-formula/tasks.md
@@ -1,0 +1,25 @@
+# Tasks
+
+## 1. Homebrew Formula
+
+- [x] 1.1 Create `Formula/cgt-tool.rb` with desc/homepage/version and macOS+Linux arches using release asset URLs
+- [x] 1.2 Add per-arch SHA256 from GitHub release checksums and set binary name in `bin.install`
+- [x] 1.3 Add `test do` block running `cgt-tool --version`
+- [x] 1.4 Run `brew audit --strict --tap velikodniy/tap cgt-tool` and fix issues
+- [x] 1.5 Run `brew install velikodniy/tap/cgt-tool` on macOS (arm64); Linux install not run here (no runner)
+
+## 2. Documentation
+
+- [x] 2.1 Update `velikodniy/cgt-tool` README with Homebrew installation steps (`tap` + `install`)
+- [x] 2.2 Update tap README to list the new `cgt-tool` formula with usage snippet (now in table)
+
+## 3. Automation
+
+- [x] 3.1 Add workflow in `velikodniy/homebrew-tap` to detect latest cgt-tool release, fetch checksums, and update formula version/sha
+- [x] 3.2 Allow manual dispatch, schedule, and repository_dispatch event; push commit with updated formula
+- [x] 3.3 Add smoke install step in the workflow (brew install cgt-tool; `cgt-tool --version`)
+
+## 4. Validation
+
+- [x] 4.1 Run `openspec validate publish-homebrew-formula --strict`
+- [x] 4.2 Capture release/version info used for the formula in the change notes (v0.1.0)


### PR DESCRIPTION
## Summary
- add openspec change documenting Homebrew tap distribution and automation
- document Homebrew install steps for cgt-tool via velikodniy/tap

Closes #5