### PR TITLE
refactor: accept Currency in FxCache::get to avoid String allocation

### DIFF
--- a/crates/cgt-money/src/amount.rs
+++ b/crates/cgt-money/src/amount.rs
@@ -52,14 +52,13 @@ impl CurrencyAmount {
             return Ok(self.amount);
         }
 
-        let code = self.currency.code();
-        let rate_entry = fx_cache.get(code, date.year(), date.month()).ok_or(
-            FxConversionError::MissingRate {
-                currency: code.to_string(),
+        let rate_entry = fx_cache
+            .get(self.currency, date.year(), date.month())
+            .ok_or(FxConversionError::MissingRate {
+                currency: self.currency.code().to_string(),
                 year: date.year(),
                 month: date.month(),
-            },
-        )?;
+            })?;
 
         Ok(self.amount / rate_entry.rate_per_gbp)
     }

--- a/crates/cgt-money/src/cache.rs
+++ b/crates/cgt-money/src/cache.rs
@@ -24,9 +24,7 @@ impl FxCache {
         }
     }
 
-    pub fn get(&self, code: &str, year: i32, month: u32) -> Option<&RateEntry> {
-        let code = code.trim().to_uppercase();
-        let currency = Currency::from_code(&code)?;
+    pub fn get(&self, currency: Currency, year: i32, month: u32) -> Option<&RateEntry> {
         let key = RateKey {
             code: currency,
             year,

--- a/crates/cgt-money/tests/parser_cache_tests.rs
+++ b/crates/cgt-money/tests/parser_cache_tests.rs
@@ -59,10 +59,10 @@ fn load_cache_merges_folder_over_bundled() {
     .unwrap();
 
     // Folder-provided rates for March 2025 should be present
-    let eur = cache.get("EUR", 2025, 3).unwrap();
+    let eur = cache.get(Currency::EUR, 2025, 3).unwrap();
     assert_eq!(eur.rate_per_gbp, Decimal::from_str_exact("1.1328").unwrap());
     // Ensure bundled rates still present
-    assert!(cache.get("USD", 2024, 12).is_some());
+    assert!(cache.get(Currency::USD, 2024, 12).is_some());
 }
 
 #[test]
@@ -78,9 +78,9 @@ fn period_mismatch_is_rejected() {
 }
 
 #[test]
-fn cache_get_is_case_insensitive() {
+fn cache_get_empty_returns_none() {
     let cache = FxCache::new();
-    assert!(cache.get("eur", 2025, 3).is_none());
+    assert!(cache.get(Currency::EUR, 2025, 3).is_none());
 }
 
 #[test]

--- a/openspec/changes/refactor-fx-cache-avoid-allocation/.openspec.yaml
+++ b/openspec/changes/refactor-fx-cache-avoid-allocation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-25

--- a/openspec/changes/refactor-fx-cache-avoid-allocation/design.md
+++ b/openspec/changes/refactor-fx-cache-avoid-allocation/design.md
@@ -1,0 +1,39 @@
+## Context
+
+`FxCache::get` currently accepts `&str` and normalizes it via `trim().to_uppercase()` on every call, allocating a `String` each time. The `Currency` enum from `iso_currency` already guarantees valid, uppercase ISO 4217 codes. All production callers have a `Currency` value available before calling `get`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Eliminate per-lookup `String` allocation in `FxCache::get`
+- Strengthen the API by accepting `Currency` instead of `&str`
+- Keep the change minimal and mechanical
+
+**Non-Goals:**
+
+- Optimizing other parts of the FX lookup path
+- Changing the `FxCache` storage format or key structure
+
+## Decisions
+
+**Accept `Currency` instead of `&str`**
+
+The `Currency` enum already guarantees a valid, uppercase ISO 4217 code. Accepting it directly:
+
+- Eliminates the `trim().to_uppercase()` allocation
+- Removes the `Currency::from_code` parse step (which can return `None`)
+- Makes invalid currency codes a compile-time or caller-side concern rather than a silent `None`
+
+Alternative considered: checking if the string is already uppercase before allocating. This would still require the `Currency::from_code` parse and doesn't improve type safety.
+
+Alternative considered: using `Cow<str>`. This adds complexity without the type-safety benefit.
+
+**Callers handle their own parsing**
+
+The MCP server receives raw user strings and must parse `Currency::from_code` itself before calling `get`. This is appropriate since the MCP server already validates and normalizes user input.
+
+## Risks / Trade-offs
+
+- [Breaking public API] `FxCache::get` signature changes. -> All callers are within this workspace and are updated together.
+- [Loss of case-insensitive lookup] Tests that pass lowercase strings will need updating. -> This convenience was unused in production; all real callers pass `Currency` values which are always correctly cased.

--- a/openspec/changes/refactor-fx-cache-avoid-allocation/proposal.md
+++ b/openspec/changes/refactor-fx-cache-avoid-allocation/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+`FxCache::get` accepts `&str` and calls `code.trim().to_uppercase()` on every lookup, allocating a new `String` each time. All production callers already have a `Currency` value available (from `CurrencyAmount::currency` or parsed upstream), making this normalization redundant and wasteful on hot paths. Accepting `Currency` directly eliminates the allocation and provides stronger type safety.
+
+## What Changes
+
+- Change `FxCache::get` signature from `(&self, code: &str, year: i32, month: u32)` to `(&self, currency: Currency, year: i32, month: u32)`
+- Remove the `trim().to_uppercase()` allocation and `Currency::from_code` parsing inside `get`
+- Update all callers in `cgt-money` (amount.rs), `cgt-mcp` (server.rs), and tests to pass `Currency` directly
+- Remove the case-insensitive lookup behavior (callers must provide a valid `Currency` enum value)
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `cgt-money`: `FxCache::get` signature changes from `&str` to `Currency` parameter. This is a **BREAKING** API change for the crate's public interface.
+
+## Impact
+
+- **cgt-money**: `FxCache::get` signature change, `CurrencyAmount::to_gbp` updated to pass `self.currency` directly
+- **cgt-mcp**: `server.rs` callers updated to parse `Currency` from user input before calling `get`
+- **Tests**: `fallback_tests.rs` and `parser_cache_tests.rs` updated to pass `Currency` values instead of string literals
+- **No behavioral change**: All production code paths produce identical results; only the case-insensitive string lookup convenience is removed

--- a/openspec/changes/refactor-fx-cache-avoid-allocation/specs/cgt-money/spec.md
+++ b/openspec/changes/refactor-fx-cache-avoid-allocation/specs/cgt-money/spec.md
@@ -1,0 +1,18 @@
+## MODIFIED Requirements
+
+### Requirement: Rate lookup
+
+The system SHALL use HMRC monthly average exchange rates for the transaction month.
+
+#### Scenario: Rate lookup
+
+- **WHEN** looking up an FX rate
+- **THEN** `FxCache::get` SHALL accept a `Currency` value, year, and month
+- **AND** return the matching `RateEntry` if present
+- **AND** return `None` if no rate exists for that currency/month
+
+#### Scenario: No string normalization
+
+- **WHEN** calling `FxCache::get`
+- **THEN** no `String` allocation SHALL occur for key lookup
+- **AND** the `Currency` enum value SHALL be used directly as the lookup key

--- a/openspec/changes/refactor-fx-cache-avoid-allocation/tasks.md
+++ b/openspec/changes/refactor-fx-cache-avoid-allocation/tasks.md
@@ -1,0 +1,17 @@
+## 1. Change FxCache::get signature
+
+- [ ] 1.1 Change `FxCache::get` in `crates/cgt-money/src/cache.rs` to accept `Currency` instead of `&str`, removing `trim().to_uppercase()` and `Currency::from_code`
+
+## 2. Update callers
+
+- [ ] 2.1 Update `CurrencyAmount::to_gbp` in `crates/cgt-money/src/amount.rs` to pass `self.currency` directly
+- [ ] 2.2 Update MCP server callers in `crates/cgt-mcp/src/server.rs` to parse `Currency` before calling `get`
+
+## 3. Update tests
+
+- [ ] 3.1 Update `crates/cgt-money/tests/fallback_tests.rs` to use `Currency` values instead of string literals
+- [ ] 3.2 Update `crates/cgt-money/tests/parser_cache_tests.rs` to use `Currency` values instead of string literals
+
+## 4. Verify
+
+- [ ] 4.1 Run `cargo fmt && cargo clippy && cargo test` and confirm all pass


### PR DESCRIPTION
## Summary
- Changes `FxCache::get` to accept `Currency` instead of `&str`, eliminating the `trim().to_uppercase()` String allocation on every lookup
- All callers already have `Currency` available, so the API is cleaner and more type-safe
- MCP server now validates currency codes before cache lookup, providing better error messages for invalid currencies

Closes #20