### PR TITLE
refactor: unify ValidationError and ValidationWarning into ValidationIssue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,7 +365,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cgt-cli"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -385,7 +385,7 @@ dependencies = [
 
 [[package]]
 name = "cgt-converter"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "cgt-core",
  "chrono",
@@ -398,7 +398,7 @@ dependencies = [
 
 [[package]]
 name = "cgt-core"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "cgt-money",
  "chrono",
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "cgt-format"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "cgt-money",
  "chrono",
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "cgt-formatter-pdf"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "cgt-core",
  "cgt-format",
@@ -438,7 +438,7 @@ dependencies = [
 
 [[package]]
 name = "cgt-formatter-plain"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "cgt-core",
  "cgt-format",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "cgt-mcp"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "cgt-core",
  "cgt-money",
@@ -464,7 +464,7 @@ dependencies = [
 
 [[package]]
 name = "cgt-money"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -481,7 +481,7 @@ dependencies = [
 
 [[package]]
 name = "cgt-wasm"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "cgt-core",
  "cgt-format",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/cgt-core", "crates/cgt-formatter-plain", "crates/cgt-formatte
 resolver = "2"
 
 [workspace.package]
-version = "0.11.2"
+version = "0.12.0"
 edition = "2024"
 
 [workspace.lints.clippy]

--- a/crates/cgt-core/src/lib.rs
+++ b/crates/cgt-core/src/lib.rs
@@ -11,4 +11,4 @@ pub use config::Config;
 pub use error::CgtError;
 pub use exemption::get_exemption;
 pub use models::*;
-pub use validation::{ValidationError, ValidationResult, ValidationWarning, validate};
+pub use validation::{Severity, ValidationIssue, ValidationResult, validate};

--- a/crates/cgt-core/src/validation.rs
+++ b/crates/cgt-core/src/validation.rs
@@ -9,13 +9,64 @@ use rust_decimal::Decimal;
 use std::collections::HashMap;
 use std::fmt;
 
+/// Severity level of a validation issue.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Severity {
+    /// Critical issue that prevents calculation.
+    Error,
+    /// Non-critical issue that doesn't prevent calculation.
+    Warning,
+}
+
+impl fmt::Display for Severity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Severity::Error => write!(f, "Error"),
+            Severity::Warning => write!(f, "Warning"),
+        }
+    }
+}
+
+/// A single validation issue (error or warning) found during input validation.
+#[derive(Debug, Clone)]
+pub struct ValidationIssue {
+    /// Whether this issue is an error or a warning.
+    pub severity: Severity,
+    /// Line number in original input (if known).
+    pub line: Option<usize>,
+    /// Date of the problematic transaction.
+    pub date: NaiveDate,
+    /// Ticker symbol involved.
+    pub ticker: String,
+    /// Description of the issue.
+    pub message: String,
+}
+
+impl fmt::Display for ValidationIssue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(line) = self.line {
+            write!(
+                f,
+                "{} (line {}): {} on {} - {}",
+                self.severity, line, self.ticker, self.date, self.message
+            )
+        } else {
+            write!(
+                f,
+                "{}: {} on {} - {}",
+                self.severity, self.ticker, self.date, self.message
+            )
+        }
+    }
+}
+
 /// Result of validating a transaction list.
 #[derive(Debug, Clone, Default)]
 pub struct ValidationResult {
     /// Critical errors that prevent calculation.
-    pub errors: Vec<ValidationError>,
+    pub errors: Vec<ValidationIssue>,
     /// Warnings that don't prevent calculation but may indicate issues.
-    pub warnings: Vec<ValidationWarning>,
+    pub warnings: Vec<ValidationIssue>,
 }
 
 impl ValidationResult {
@@ -27,68 +78,6 @@ impl ValidationResult {
     /// Returns true if there are no errors or warnings.
     pub fn is_clean(&self) -> bool {
         self.errors.is_empty() && self.warnings.is_empty()
-    }
-}
-
-/// A validation error that prevents calculation.
-#[derive(Debug, Clone)]
-pub struct ValidationError {
-    /// Line number in original input (if known).
-    pub line: Option<usize>,
-    /// Date of the problematic transaction.
-    pub date: NaiveDate,
-    /// Ticker symbol involved.
-    pub ticker: String,
-    /// Description of the error.
-    pub message: String,
-}
-
-impl fmt::Display for ValidationError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Some(line) = self.line {
-            write!(
-                f,
-                "Error (line {}): {} on {} - {}",
-                line, self.ticker, self.date, self.message
-            )
-        } else {
-            write!(
-                f,
-                "Error: {} on {} - {}",
-                self.ticker, self.date, self.message
-            )
-        }
-    }
-}
-
-/// A validation warning that doesn't prevent calculation.
-#[derive(Debug, Clone)]
-pub struct ValidationWarning {
-    /// Line number in original input (if known).
-    pub line: Option<usize>,
-    /// Date of the problematic transaction.
-    pub date: NaiveDate,
-    /// Ticker symbol involved.
-    pub ticker: String,
-    /// Description of the warning.
-    pub message: String,
-}
-
-impl fmt::Display for ValidationWarning {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Some(line) = self.line {
-            write!(
-                f,
-                "Warning (line {}): {} on {} - {}",
-                line, self.ticker, self.date, self.message
-            )
-        } else {
-            write!(
-                f,
-                "Warning: {} on {} - {}",
-                self.ticker, self.date, self.message
-            )
-        }
     }
 }
 
@@ -122,7 +111,8 @@ pub fn validate(transactions: &[Transaction]) -> ValidationResult {
             } => {
                 // Check zero quantity
                 if *amount == Decimal::ZERO {
-                    result.errors.push(ValidationError {
+                    result.errors.push(ValidationIssue {
+                        severity: Severity::Error,
                         line,
                         date: tx.date,
                         ticker: tx.ticker.clone(),
@@ -132,7 +122,8 @@ pub fn validate(transactions: &[Transaction]) -> ValidationResult {
 
                 // Check negative quantity
                 if *amount < Decimal::ZERO {
-                    result.errors.push(ValidationError {
+                    result.errors.push(ValidationIssue {
+                        severity: Severity::Error,
                         line,
                         date: tx.date,
                         ticker: tx.ticker.clone(),
@@ -142,7 +133,8 @@ pub fn validate(transactions: &[Transaction]) -> ValidationResult {
 
                 // Check negative price (GBP value)
                 if price.amount < Decimal::ZERO {
-                    result.errors.push(ValidationError {
+                    result.errors.push(ValidationIssue {
+                        severity: Severity::Error,
                         line,
                         date: tx.date,
                         ticker: tx.ticker.clone(),
@@ -152,7 +144,8 @@ pub fn validate(transactions: &[Transaction]) -> ValidationResult {
 
                 // Check negative fees (GBP value)
                 if fees.amount < Decimal::ZERO {
-                    result.errors.push(ValidationError {
+                    result.errors.push(ValidationIssue {
+                        severity: Severity::Error,
                         line,
                         date: tx.date,
                         ticker: tx.ticker.clone(),
@@ -178,7 +171,8 @@ pub fn validate(transactions: &[Transaction]) -> ValidationResult {
             } => {
                 // Check zero quantity
                 if *amount == Decimal::ZERO {
-                    result.errors.push(ValidationError {
+                    result.errors.push(ValidationIssue {
+                        severity: Severity::Error,
                         line,
                         date: tx.date,
                         ticker: tx.ticker.clone(),
@@ -188,7 +182,8 @@ pub fn validate(transactions: &[Transaction]) -> ValidationResult {
 
                 // Check negative quantity
                 if *amount < Decimal::ZERO {
-                    result.errors.push(ValidationError {
+                    result.errors.push(ValidationIssue {
+                        severity: Severity::Error,
                         line,
                         date: tx.date,
                         ticker: tx.ticker.clone(),
@@ -198,7 +193,8 @@ pub fn validate(transactions: &[Transaction]) -> ValidationResult {
 
                 // Check negative price (GBP value)
                 if price.amount < Decimal::ZERO {
-                    result.errors.push(ValidationError {
+                    result.errors.push(ValidationIssue {
+                        severity: Severity::Error,
                         line,
                         date: tx.date,
                         ticker: tx.ticker.clone(),
@@ -208,7 +204,8 @@ pub fn validate(transactions: &[Transaction]) -> ValidationResult {
 
                 // Check negative fees (GBP value)
                 if fees.amount < Decimal::ZERO {
-                    result.errors.push(ValidationError {
+                    result.errors.push(ValidationIssue {
+                        severity: Severity::Error,
                         line,
                         date: tx.date,
                         ticker: tx.ticker.clone(),
@@ -219,7 +216,8 @@ pub fn validate(transactions: &[Transaction]) -> ValidationResult {
                 // Check for sell before buy (warning)
                 if let Some(&first_buy_date) = first_buy.get(tx.ticker.as_str()) {
                     if tx.date < first_buy_date {
-                        result.warnings.push(ValidationWarning {
+                        result.warnings.push(ValidationIssue {
+                            severity: Severity::Warning,
                             line,
                             date: tx.date,
                             ticker: tx.ticker.clone(),
@@ -230,7 +228,8 @@ pub fn validate(transactions: &[Transaction]) -> ValidationResult {
                         });
                     }
                 } else {
-                    result.warnings.push(ValidationWarning {
+                    result.warnings.push(ValidationIssue {
+                        severity: Severity::Warning,
                         line,
                         date: tx.date,
                         ticker: tx.ticker.clone(),
@@ -242,7 +241,8 @@ pub fn validate(transactions: &[Transaction]) -> ValidationResult {
             Operation::Split { ratio } => {
                 // Check zero ratio
                 if *ratio == Decimal::ZERO {
-                    result.errors.push(ValidationError {
+                    result.errors.push(ValidationIssue {
+                        severity: Severity::Error,
                         line,
                         date: tx.date,
                         ticker: tx.ticker.clone(),
@@ -252,7 +252,8 @@ pub fn validate(transactions: &[Transaction]) -> ValidationResult {
 
                 // Check negative ratio
                 if *ratio < Decimal::ZERO {
-                    result.errors.push(ValidationError {
+                    result.errors.push(ValidationIssue {
+                        severity: Severity::Error,
                         line,
                         date: tx.date,
                         ticker: tx.ticker.clone(),
@@ -264,7 +265,8 @@ pub fn validate(transactions: &[Transaction]) -> ValidationResult {
             Operation::Unsplit { ratio } => {
                 // Check zero ratio
                 if *ratio == Decimal::ZERO {
-                    result.errors.push(ValidationError {
+                    result.errors.push(ValidationIssue {
+                        severity: Severity::Error,
                         line,
                         date: tx.date,
                         ticker: tx.ticker.clone(),
@@ -274,7 +276,8 @@ pub fn validate(transactions: &[Transaction]) -> ValidationResult {
 
                 // Check negative ratio
                 if *ratio < Decimal::ZERO {
-                    result.errors.push(ValidationError {
+                    result.errors.push(ValidationIssue {
+                        severity: Severity::Error,
                         line,
                         date: tx.date,
                         ticker: tx.ticker.clone(),
@@ -290,7 +293,8 @@ pub fn validate(transactions: &[Transaction]) -> ValidationResult {
             } => {
                 // Check zero quantity
                 if *amount == Decimal::ZERO {
-                    result.errors.push(ValidationError {
+                    result.errors.push(ValidationIssue {
+                        severity: Severity::Error,
                         line,
                         date: tx.date,
                         ticker: tx.ticker.clone(),
@@ -300,7 +304,8 @@ pub fn validate(transactions: &[Transaction]) -> ValidationResult {
 
                 // Check negative quantity
                 if *amount < Decimal::ZERO {
-                    result.errors.push(ValidationError {
+                    result.errors.push(ValidationIssue {
+                        severity: Severity::Error,
                         line,
                         date: tx.date,
                         ticker: tx.ticker.clone(),
@@ -310,7 +315,8 @@ pub fn validate(transactions: &[Transaction]) -> ValidationResult {
 
                 // Check negative total value (GBP value)
                 if total_value.amount < Decimal::ZERO {
-                    result.errors.push(ValidationError {
+                    result.errors.push(ValidationIssue {
+                        severity: Severity::Error,
                         line,
                         date: tx.date,
                         ticker: tx.ticker.clone(),
@@ -329,7 +335,8 @@ pub fn validate(transactions: &[Transaction]) -> ValidationResult {
             } => {
                 // Check zero quantity
                 if *amount == Decimal::ZERO {
-                    result.errors.push(ValidationError {
+                    result.errors.push(ValidationIssue {
+                        severity: Severity::Error,
                         line,
                         date: tx.date,
                         ticker: tx.ticker.clone(),
@@ -339,7 +346,8 @@ pub fn validate(transactions: &[Transaction]) -> ValidationResult {
 
                 // Check negative quantity
                 if *amount < Decimal::ZERO {
-                    result.errors.push(ValidationError {
+                    result.errors.push(ValidationIssue {
+                        severity: Severity::Error,
                         line,
                         date: tx.date,
                         ticker: tx.ticker.clone(),
@@ -349,7 +357,8 @@ pub fn validate(transactions: &[Transaction]) -> ValidationResult {
 
                 // Check negative total value (GBP value)
                 if total_value.amount < Decimal::ZERO {
-                    result.errors.push(ValidationError {
+                    result.errors.push(ValidationIssue {
+                        severity: Severity::Error,
                         line,
                         date: tx.date,
                         ticker: tx.ticker.clone(),
@@ -362,7 +371,8 @@ pub fn validate(transactions: &[Transaction]) -> ValidationResult {
 
                 // Check negative fees (GBP value)
                 if fees.amount < Decimal::ZERO {
-                    result.errors.push(ValidationError {
+                    result.errors.push(ValidationIssue {
+                        severity: Severity::Error,
                         line,
                         date: tx.date,
                         ticker: tx.ticker.clone(),

--- a/crates/cgt-wasm/src/lib.rs
+++ b/crates/cgt-wasm/src/lib.rs
@@ -1,6 +1,4 @@
-use cgt_core::{
-    Disposal, ValidationError, ValidationWarning, calculator, get_exemption, parser, validate,
-};
+use cgt_core::{Disposal, ValidationIssue, calculator, get_exemption, parser, validate};
 use cgt_money::load_default_cache;
 use rust_decimal::Decimal;
 use serde::Serialize;
@@ -13,12 +11,12 @@ use utils::map_error;
 #[derive(Serialize)]
 struct ValidationResultJson {
     is_valid: bool,
-    errors: Vec<ValidationErrorJson>,
-    warnings: Vec<ValidationWarningJson>,
+    errors: Vec<ValidationIssueJson>,
+    warnings: Vec<ValidationIssueJson>,
 }
 
 #[derive(Serialize)]
-struct ValidationErrorJson {
+struct ValidationIssueJson {
     #[serde(skip_serializing_if = "Option::is_none")]
     line: Option<usize>,
     date: String,
@@ -26,33 +24,13 @@ struct ValidationErrorJson {
     message: String,
 }
 
-#[derive(Serialize)]
-struct ValidationWarningJson {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    line: Option<usize>,
-    date: String,
-    ticker: String,
-    message: String,
-}
-
-impl From<&ValidationError> for ValidationErrorJson {
-    fn from(error: &ValidationError) -> Self {
-        ValidationErrorJson {
-            line: error.line,
-            date: error.date.to_string(),
-            ticker: error.ticker.clone(),
-            message: error.message.clone(),
-        }
-    }
-}
-
-impl From<&ValidationWarning> for ValidationWarningJson {
-    fn from(warning: &ValidationWarning) -> Self {
-        ValidationWarningJson {
-            line: warning.line,
-            date: warning.date.to_string(),
-            ticker: warning.ticker.clone(),
-            message: warning.message.clone(),
+impl From<&ValidationIssue> for ValidationIssueJson {
+    fn from(issue: &ValidationIssue) -> Self {
+        ValidationIssueJson {
+            line: issue.line,
+            date: issue.date.to_string(),
+            ticker: issue.ticker.clone(),
+            message: issue.message.clone(),
         }
     }
 }

--- a/openspec/changes/refactor-merge-validation-error-warning/.openspec.yaml
+++ b/openspec/changes/refactor-merge-validation-error-warning/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-25

--- a/openspec/changes/refactor-merge-validation-error-warning/design.md
+++ b/openspec/changes/refactor-merge-validation-error-warning/design.md
@@ -1,0 +1,46 @@
+## Context
+
+`cgt-core` defines two structurally identical types (`ValidationError`, `ValidationWarning`) with the same four fields and near-identical `Display` impls. These are public types re-exported from `cgt-core::lib.rs` and consumed by `cgt-wasm`. No other crates (CLI, MCP, formatters) reference them directly.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Eliminate structural duplication by merging the two types into one
+- Preserve identical `Display` output and validation semantics
+- Keep `ValidationResult` API ergonomic for consumers that distinguish errors from warnings
+
+**Non-Goals:**
+
+- Changing validation logic or adding new validation checks
+- Merging the `errors` and `warnings` vectors in `ValidationResult` into a single list (keeping separate vectors is cleaner for consumers)
+
+## Decisions
+
+### 1. Introduce `Severity` enum and `ValidationIssue` struct
+
+Replace `ValidationError` and `ValidationWarning` with:
+
+```rust
+enum Severity { Error, Warning }
+struct ValidationIssue { severity, line, date, ticker, message }
+```
+
+**Rationale**: Direct mechanical replacement. The severity field captures the only difference between the two types.
+
+**Alternative considered**: A single `Vec<ValidationIssue>` in `ValidationResult` with filtering by severity. Rejected because it forces every consumer to filter, and the existing two-vector pattern (`errors`, `warnings`) is clearer and already well-tested.
+
+### 2. Keep separate `errors` and `warnings` fields in `ValidationResult`
+
+Both fields become `Vec<ValidationIssue>`. Construction code sets the appropriate `Severity` variant.
+
+**Rationale**: Minimizes churn in consumers. Tests already access `result.errors` and `result.warnings` directly.
+
+### 3. Update WASM JSON bridge with unified conversion
+
+The WASM crate's `ValidationErrorJson` and `ValidationWarningJson` are also structurally identical. Unify them into `ValidationIssueJson` with a single `From<&ValidationIssue>` impl.
+
+## Risks / Trade-offs
+
+- **[Breaking public API]** → Acceptable for a pre-1.0 crate. The old type names are removed. Consumers must update imports. Mitigated by the fact that only `cgt-wasm` is an external consumer.
+- **[Severity mismatch possible]** → A `ValidationIssue` with `Severity::Warning` could theoretically be pushed to the `errors` vec. This is an internal-only concern; the `validate()` function is the sole producer. No mitigation needed beyond code review.

--- a/openspec/changes/refactor-merge-validation-error-warning/proposal.md
+++ b/openspec/changes/refactor-merge-validation-error-warning/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+`ValidationError` and `ValidationWarning` in `cgt-core` are structurally identical types (same fields: `line`, `date`, `ticker`, `message`) with nearly identical `Display` impls differing only in the "Error"/"Warning" prefix. This is ~60 lines of unnecessary duplication that increases maintenance burden and makes future field additions require changes in two places.
+
+## What Changes
+
+- Replace `ValidationError` and `ValidationWarning` with a single `ValidationIssue` struct containing a `Severity` enum field
+- Unify the two `Display` impls into one that uses the severity for the prefix
+- Update `ValidationResult` fields and all consumers (cgt-core re-exports, cgt-wasm JSON bridge)
+- **BREAKING**: Public API types `ValidationError` and `ValidationWarning` are removed in favor of `Severity` and `ValidationIssue`
+
+## Capabilities
+
+### New Capabilities
+
+(none — this is a pure refactor of existing internal types)
+
+### Modified Capabilities
+
+(none — no spec-level behavior changes; validation still produces errors and warnings with the same semantics)
+
+## Impact
+
+- `crates/cgt-core/src/validation.rs` — primary change location
+- `crates/cgt-core/src/lib.rs` — re-export update
+- `crates/cgt-wasm/src/lib.rs` — JSON bridge `From` impls
+- `crates/cgt-core/tests/validation_tests.rs` — tests access `.errors` and `.warnings` fields on `ValidationResult`
+
+## Verification
+
+All existing tests must pass unchanged. `cargo fmt && cargo clippy && cargo test` must succeed. The refactored types produce identical `Display` output and identical validation behavior.

--- a/openspec/changes/refactor-merge-validation-error-warning/specs/validation/spec.md
+++ b/openspec/changes/refactor-merge-validation-error-warning/specs/validation/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Unified validation issue type
+
+The validation module SHALL represent all validation issues (errors and warnings) using a single `ValidationIssue` struct with a `Severity` enum distinguishing between `Error` and `Warning` severity levels.
+
+#### Scenario: Error display format preserved
+
+- **WHEN** a `ValidationIssue` with `Severity::Error` and a line number is displayed
+- **THEN** the output SHALL match the format `Error (line N): TICKER on DATE - MESSAGE`
+
+#### Scenario: Warning display format preserved
+
+- **WHEN** a `ValidationIssue` with `Severity::Warning` and a line number is displayed
+- **THEN** the output SHALL match the format `Warning (line N): TICKER on DATE - MESSAGE`
+
+#### Scenario: Display without line number
+
+- **WHEN** a `ValidationIssue` with `line: None` is displayed
+- **THEN** the output SHALL omit the `(line N)` portion
+
+#### Scenario: ValidationResult retains separate access
+
+- **WHEN** validation produces both errors and warnings
+- **THEN** `ValidationResult` SHALL provide separate `errors` and `warnings` fields, both typed as `Vec<ValidationIssue>`

--- a/openspec/changes/refactor-merge-validation-error-warning/tasks.md
+++ b/openspec/changes/refactor-merge-validation-error-warning/tasks.md
@@ -1,0 +1,15 @@
+## 1. Core type refactor in cgt-core
+
+- [ ] 1.1 Replace `ValidationError` and `ValidationWarning` with `Severity` enum and `ValidationIssue` struct in `crates/cgt-core/src/validation.rs`
+- [ ] 1.2 Implement unified `Display` for `ValidationIssue` using severity prefix
+- [ ] 1.3 Update `ValidationResult` fields to use `Vec<ValidationIssue>`
+- [ ] 1.4 Update all `ValidationError { .. }` and `ValidationWarning { .. }` construction sites in `validate()` to use `ValidationIssue`
+
+## 2. Update public API and consumers
+
+- [ ] 2.1 Update re-exports in `crates/cgt-core/src/lib.rs`
+- [ ] 2.2 Update `crates/cgt-wasm/src/lib.rs` JSON bridge types and `From` impls
+
+## 3. Verify
+
+- [ ] 3.1 Run `cargo fmt && cargo clippy && cargo test` and confirm all pass


### PR DESCRIPTION
## Summary
- Introduces `Severity` enum and unified `ValidationIssue` type replacing structurally identical `ValidationError` and `ValidationWarning`
- Eliminates ~60 lines of duplication (two identical structs, two near-identical `Display` impls)
- Single `Display` impl uses severity for "Error"/"Warning" prefix
- Updates all consumers: `cgt-core` re-exports and `cgt-wasm` JSON bridge

Closes #18